### PR TITLE
Add crashdump timeout env to get crash dumps

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -44,7 +44,10 @@
 #--run-on-exit /bin/sh
 
 # Enable UTF-8 filename handling in Erlang and custom inet configuration
--e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump
+-e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc
+
+# Enable crash dumps (set ERL_CRASH_DUMP_SECONDS=0 to disable)
+-e ERL_CRASH_DUMP=/root/erl_crash.dump;ERL_CRASH_DUMP_SECONDS=5
 
 # Mount the application partition (run "man fstab" for field names)
 # NOTE: This must match the location in the fwup.conf. If it doesn't the system


### PR DESCRIPTION
At some point in time, crash dumps stopped working due to the missing
timeout. Given that these come in handy every once in a while, add the
missing environment variable to avoid having to remember that no dumps
are made without it.
