### PR TITLE
Associate PMOD UART pinmux with uart4

### DIFF
--- a/linux/imx6ul-grisp2.dts
+++ b/linux/imx6ul-grisp2.dts
@@ -493,6 +493,11 @@
 &pin_gpio {
 	/delete-property/ grisp,gpios;
 };
+&uart4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart4>;
+	status = "okay";
+};
 / {
 	rmem: reserved-memory {
 		#address-cells = <1>;


### PR DESCRIPTION
This makes it possible to use the PMOD UART via /dev/ttymxc3. Switching
the PMOD connector to GPIO mode isn't supported at runtime, but can be
done by changing uart4's `status = "okay";` to `status = "disabled";`

Fixes #52
